### PR TITLE
Implementing Restart Button to Return to Menu Screen

### DIFF
--- a/components/BattleScreen/BattleScreen.js
+++ b/components/BattleScreen/BattleScreen.js
@@ -28,7 +28,7 @@ function Battle({
   selectedEnemyPokemon,
   selectedEnemyPokemons,
   setSelectedEnemyPokemon,
-  setAttackMessage,
+  resetSelection,
 }) {
   const {
     playerHealth,
@@ -52,9 +52,9 @@ function Battle({
   const enemyPokemon = selectedEnemyPokemon;
 
   if (playerHealth <= 0) {
-    return <LoserMessage />;
+    return <LoserMessage resetSelection={resetSelection} />;
   } else if (victory) {
-    return <VictoryMessage />;
+    return <VictoryMessage resetSelection={resetSelection} />;
   }
 
   return (
@@ -85,6 +85,7 @@ function Battle({
         attacks={selectedPokemon.attacks}
         name={selectedPokemon.name}
         onPotionUse={handlePotionUse}
+        onResetSelection={resetSelection}
       />
       {attackMessage && (
         <AttackMessage
@@ -105,6 +106,11 @@ export default function BattleScreen() {
   const [selectedPokemon, setSelectedPokemon] = useState(null);
   const [selectedEnemyPokemon, setSelectedEnemyPokemon] = useState(null);
   const [selectedEnemyPokemons, setSelectedEnemyPokemons] = useState(null);
+
+  const resetSelection = () => {
+    setSelectedPokemon(null);
+    setSelectedEnemyPokemon(null);
+  };
 
   const handlePokemonSelection = (pokemon) => {
     setSelectedPokemon(pokemon);
@@ -140,6 +146,7 @@ export default function BattleScreen() {
         selectedEnemyPokemon={selectedEnemyPokemon}
         selectedEnemyPokemons={selectedEnemyPokemons}
         setSelectedEnemyPokemon={setSelectedEnemyPokemon}
+        resetSelection={resetSelection}
       />
     </>
   );

--- a/components/BattleScreen/Menu/Menu.js
+++ b/components/BattleScreen/Menu/Menu.js
@@ -4,7 +4,14 @@ import AttackMenu from "./AttackMenu";
 import SoundEffects from "../SoundEffect/SoundEffect";
 import Bag from "./Bag";
 
-const Menu = ({ onAttack, onPotionUse, disabled, attacks, name }) => {
+const Menu = ({
+  onAttack,
+  onPotionUse,
+  disabled,
+  attacks,
+  name,
+  onResetSelection,
+}) => {
   const [showAttackMenu, setShowAttackMenu] = useState(false);
   const [showBag, setShowBag] = useState(false);
   const [playSound, stopSound] = SoundEffects();
@@ -106,7 +113,7 @@ const Menu = ({ onAttack, onPotionUse, disabled, attacks, name }) => {
                 setHoveredButton(null);
               }}
               onClick={() => {
-                window.location.reload();
+                onResetSelection();
               }}
               disabled={disabled}
             >

--- a/components/BattleScreen/Message/LoserMessage.js
+++ b/components/BattleScreen/Message/LoserMessage.js
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
-export default function LoserMessage() {
+export default function LoserMessage({ resetSelection }) {
   const handleRestart = () => {
-    window.location.reload();
+    resetSelection();
   };
   return (
     <LoserMessageMessageContainer>

--- a/components/BattleScreen/Message/VictoryMessage.js
+++ b/components/BattleScreen/Message/VictoryMessage.js
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 
-export default function VictoryMessage() {
+export default function VictoryMessage({ resetSelection }) {
   const handleRestart = () => {
-    window.location.reload();
+    resetSelection();
   };
 
   return (


### PR DESCRIPTION
I only changed the handleRestart function so that the page is not reloaded but the resetSelection is executed. 
This takes the player back to the selection menu and does not restart the whole app.